### PR TITLE
feat: DatepickerV2 can now have a custom text displayed in its input …

### DIFF
--- a/src/components/inputs/datepickerv2/Datepicker.stories.mdx
+++ b/src/components/inputs/datepickerv2/Datepicker.stories.mdx
@@ -207,3 +207,22 @@ For a single date, the controller component must inject a _`value`_ prop. The on
     </Box>
   </Story>
 </Preview>
+
+## Custom input text
+
+<Preview>
+  <Story name="Custom input text">
+    <Box>
+      <Datepicker
+        isRange
+        numberOfMonths={2}
+        initialDate={{
+          startDate: new Date(),
+          endDate: new Date(),
+          focusedInput: 'startDate',
+        }}
+        customInputText="Today"
+      />
+    </Box>
+  </Story>
+</Preview>

--- a/src/components/inputs/datepickerv2/index.js
+++ b/src/components/inputs/datepickerv2/index.js
@@ -38,6 +38,7 @@ const DatepickerV2 = (props) => {
     initialDate = DEFAULT_STATE,
     isDateBlocked,
     theme,
+    customInputText,
   } = props;
   const inputRef = useRef();
   const [isOpen, setIsOpen] = useState(false);
@@ -162,7 +163,7 @@ const DatepickerV2 = (props) => {
           size={size}
           disabled={disabled}
           errorMessage={errorMessage}
-          value={formatDate(state, { isRange })}
+          value={customInputText || formatDate(state, { isRange })}
           onMouseEnter={() => setMouseLeaveInput(false)}
           onMouseLeave={() => setMouseLeaveInput(true)}
         />
@@ -195,6 +196,8 @@ DatepickerV2.propTypes = {
   defaultInitialVisibleMonth: PropTypes.any,
   onDateChange: PropTypes.func,
   isDateBlocked: PropTypes.func,
+  theme: PropTypes.any,
+  customInputText: PropTypes.string,
 };
 
 export default withTheme(DatepickerV2);


### PR DESCRIPTION
Storybook > Inputs > Datepicker V2 > Custom input text


Jira: https://perzoinc.atlassian.net/browse/SYM-3682
Related feedback: https://perzoinc.atlassian.net/browse/SYM-3682?focusedCommentId=718570

As presets are only on the blotter side, we need to manage it by adding a custom props for the Datepicker